### PR TITLE
Fixed importing issue

### DIFF
--- a/ctpktool/CTPKEntry.cs
+++ b/ctpktool/CTPKEntry.cs
@@ -156,8 +156,8 @@ namespace ctpktool
 
             if (!String.IsNullOrWhiteSpace(dir))
             {
-                //if (!String.IsNullOrWhiteSpace(outputFolder))
-                //    dir = Path.Combine(outputFolder, dir);
+                if (!String.IsNullOrWhiteSpace(outputFolder))
+                    dir = Path.Combine(outputFolder, dir);
 
                 filename = Path.Combine(dir, filename);
 

--- a/ctpktool/Program.cs
+++ b/ctpktool/Program.cs
@@ -15,7 +15,7 @@ namespace ctpktool
             var settings = new CommandLine.ParserSettings(true, true, false, Console.Error);
             var parser = new CommandLine.Parser(settings);
 
-            string inputPath = "", outputPath = "";
+            string inputPath = "*", outputPath = "*";
             bool isExtract = false, isRawExtract = false, isCreate = false;
 
             if (parser.ParseArguments(args, config))


### PR DESCRIPTION
Two lines of code were necessary to run the tool properly, but were made as comments in versions 1.2 and 1.3.
You define inputPath and outputPath as a blank, which causes an ArgumentException error because blanks are invalid characters. Replaced with asterisks as wildcards. 

